### PR TITLE
Add support for Graylog 4.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.graylog.plugins</groupId>
     <artifactId>graylog-plugin-slookup-function</artifactId>
-    <version>2.0.0</version>
+    <version>4.1.0</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -34,7 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <graylog.version>2.3.2</graylog.version>
+        <graylog.version>4.1.0</graylog.version>
         <graylog.plugin-dir>/usr/share/graylog-server/plugin</graylog.plugin-dir>
     </properties>
 
@@ -46,10 +46,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.graylog.plugins</groupId>
-            <artifactId>graylog-plugin-pipeline-processor</artifactId>
-            <version>1.1.1</version>
-            <scope>provided</scope>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>7.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>7.7.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Changes for StreamLookupFunction.java

    1) Added required elasticsearch import for SortOrder
    org.elasticsearch.search.sort.SortOrder;

    2) Remove asElastic() as this method is no longer used

    3) Switch timeRange builder to create which was changed when optional from/to fields were added in Graylog 4.1
       See https://github.com/Graylog2/graylog2-server/pull/9899/files

Changes for pom.xml

    1) Added Elasticsearch 7.7 dependencies

    2) Change Graylog version from 2.3.2 to 4.1.0
    
    3) Removed graylog-plugin-pipeline-processor dependency

    3) Change graylog-plugin-slookup-function to version 4.1.0 to indicate that it's for 4.1.x Graylog
  
  Tested on Graylog 4.1.5
  For version 4.0.5 to work revert the this.timeRange change on line 91 and switch Graylog versions in pom.xml